### PR TITLE
adding notts & notts ICS to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ github_org_dict:
     "NHS.UK": "nhsuk",
     "Public Health England": "publichealthengland",
     "Nottinghamshire Healthcare NHS Foundation Trust - CDU Data Science Team": "CDU-data-science-team",
+    "Nottingham and Nottinghamshire ICS": "Nottingham-and-Nottinghamshire-ICS",
     "NHS Midlands and Lancashire CSU - The Strategy Unit": "the-strategy-unit",
     "University of Oxford - Evidence-Based Medicine Data Lab": "ebmdatalab",
     "OpenSAFELY Studies": "opensafely",


### PR DESCRIPTION
I saw this list in a post you made to the NHS-R Slack.  This PR adds the Notts & Notts ICS github page to the list.